### PR TITLE
Simplified media upload process description

### DIFF
--- a/docs/API/media-library.md
+++ b/docs/API/media-library.md
@@ -65,10 +65,12 @@ To get list of images with metadata use `GET /api/v1/content/_media` endpoint.
 Fetching original or resized files directly is described in the next sections.
 
 
-### The Media Content Type Definition
+## Media Content Object
 
-As we see in the response uploaded media has its own representation as Content Object. Below we listed
-all parameters describing the `Media` object.
+As we see in the response uploaded media has its own representation as Content Object. You can use all the content 
+api methods to get, list, remove Content objects. Be aware, that changing the `_media` metadata can lead to unexpected behaviour.
+
+Below we listed all parameters describing the `Media` object.
 
 | Parameter  | Description |
 | ---------- | ----------- |
@@ -84,7 +86,9 @@ all parameters describing the `Media` object.
 | height     | Height, or 0 for 'file' type |
 | width      | Width, or 0 for 'file' type |
 
-All parameters are described also in the `Media` Content Type Definition.
+### Media Content Type Definition
+
+All the Media Content Object parameters are described also in the `Media` Content Type Definition.
 
 ??? "Structure of the `_media` Content Type Definition:"
     ```json
@@ -217,10 +221,6 @@ All parameters are described also in the `Media` Content Type Definition.
     ```
 
 
-
-##Content Object
-
-Media upload endpoint creates Content Object automatically when you use `save = 1` parameter. It would be best if you only used `getMedia` and `listMedia` endpoints, as changing the `_media` objects can lead to unexpected behaviour.
 
 
 ##Viewing and resizing photos, returning files

--- a/docs/API/media-library.md
+++ b/docs/API/media-library.md
@@ -3,29 +3,23 @@ description: Learn more about the powerful Media Library that Flotiq offers.
 
 #Media library
 
-To upload the file to the media library, you need to send `POST` multipart request to `/api/media` endpoint. The response will be a Content Object of type `_media`.
-    
-!!! hint
-    You can also download files from Unsplash, to do this, enter the id of the Unsplash photo on `/api/unsplash/{id}` endpoint (via `GET` request), the photo will be automatically downloaded to the server. The response will be the same as for image upload. 
-
-
-??? "Deprecated, old, two steps way"
-    The process of uploading files to the media library consists of two steps:
-    
-    1. Upload the file to `/api/media` endpoint (via a `POST` request). The response
-       will be a JSON payload with information about the created entity.
-        
-        !!! hint
-            You can also download files from Unsplash, to do this, enter the id of the Unsplash photo on `/api/unsplash/{id}` endpoint (via `GET` request), the photo will be automatically downloaded to the server. The response will be the same as for image upload. 
-        
-    
-    2. Next step is to transfer the information about the saved file as a Content Object compatible with Content Type Definition of `_media` type to the `/api/v1/content/_media`  endpoint.
-    
-    We describe both steps in details below.
+You can interact with the media library via Flotiq Dashboard or REST API. In this section, we show you how to use our REST API to store and retrieve files.
 
 ##File upload
 
-Because sending and storing files as their base64 hash is ineffective, files have to be uploaded to the Content Repository first. To save the file as Content Object while uploading it, set the `save` flag to `1`.
+To upload a file to the Flotiq, you need to send `POST` multipart request to `/api/media` endpoint with required request parameters.
+
+### Request parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| file      | binary data of a file |
+| type      | `image` for image types, `file` for everything else |
+| save      | set `1` to upload file to server and create an entity in the media library, `0` is deprecated |
+
+To use the uploaded file in media library remember to set the `save` flag to `1`. Option with `0` is deprecated. 
+
+Below example shows how to do simple file upload in nodeJS application:
 
 !!! example "Example nodeJs image upload"
     ```js
@@ -36,13 +30,17 @@ Because sending and storing files as their base64 hash is ineffective, files hav
     form.append(`file`, fs.createReadStream(file), file);
     form.append(`type`, `image`);
     form.append(`save`, 1);
-    let json = await fetch(apiUrl + `/api/media`, {
+    let json = await fetch(`https://api.flotiq.com/api/media`, {
         method: `POST`,
         body: form,
         headers: headers,
     }).then(res => res.json());
     console.log(json); //logs example object return shown below
     ```
+
+### Response parameters
+
+The response will be a Content Object of type `_media`. 
 
 !!! example "Example response"
     ```json
@@ -60,24 +58,33 @@ Because sending and storing files as their base64 hash is ineffective, files hav
         "width": 150
     }
     ```
-
-### Request parameters
-
-| Parameter | Description |
-| --------- | ----------- |
-| file      | binary data of a file |
-| type      | `image` for image types, `file` for everything else |
-| save      | information if the file should be saved as the Content Object without sending another request, `0` or `1`, default `0`, for the intended way of saving images, use `1` |
-
-??? "Deprecated, old, two steps way"
-
-    Because sending and storing files as their base64 hash is ineffective, files have to be uploaded to the Content Repository first. That way, the entity URL can be used when creating a proper `_media` Content Object.
     
-    To use this way, do not set the `save` flag or set it to `0`.
-    
-    The returned keys match the keys of the `_media` Content Type Definition.
+Now you can see uploaded images in the media library. Your files are accessible also via REST API like other Content Objects. 
+To get list of images with metadata use `GET /api/v1/content/_media` endpoint.
 
-##Content Type Definition
+Fetching original or resized files directly is described in the next sections.
+
+
+### The Media Content Type Definition
+
+As we see in the response uploaded media has its own representation as Content Object. Below we listed
+all parameters describing the `Media` object.
+
+| Parameter  | Description |
+| ---------- | ----------- |
+| id         | The id is given by the backend by which the file on the disk is named. The `id` property is unique, final and immutable and is used to create the URI of the uploaded object. |
+| extension  | File extension without dot |
+| fileName   | Full name of uploaded file |
+| mimeType   | Mime type of uploaded file |
+| size       | Size of file in bytes |
+| type       | Type of the file, it can be 'image' or 'file' |
+| source     | Source of the file, it can be 'disk' or 'unsplash' |
+| externalId | Id of the photo on unsplash if it was downloaded from there
+| url        | Url to original image without API host (e.g. /image/0x0/_media-456456.jpg) |
+| height     | Height, or 0 for 'file' type |
+| width      | Width, or 0 for 'file' type |
+
+All parameters are described also in the `Media` Content Type Definition.
 
 ??? "Structure of the `_media` Content Type Definition:"
     ```json
@@ -152,44 +159,54 @@ Because sending and storing files as their base64 hash is ineffective, files hav
             ],
             "propertiesConfig": {
                 "fileName": {
+                    "label": "File name",
                     "inputType": "text",
                     "unique": false,
                     "idTitlePart": true
                 },
                 "mimeType": {
+                    "label": "MIME type",
                     "inputType": "text",
                     "unique": false
                 },
                 "size": {
+                    "label": "Size",
                     "inputType": "number",
                     "unique": false
                 },
                 "width": {
+                    "label": "Width",
                     "inputType": "number",
                     "unique": false
                 },
                 "height": {
+                    "label": "Height",
                     "inputType": "number",
                     "unique": false
                 },
                 "url": {
+                    "label": "Url",
                     "inputType": "text",
                     "unique": false
                 },
                 "externalId": {
+                    "label": "External id",
                     "inputType": "text",
                     "unique": false
                 },
                 "source": {
+                    "label": "Source",
                     "inputType": "select",
                     "unique": false,
                     "options": ["disk","unsplash"]
                 },
                 "extension": {
+                    "label": "Extension",
                     "inputType": "text",
                     "unique": false
                 },
                 "type": {
+                    "label": "Type",
                     "inputType": "select",
                     "unique": false,
                     "options": ["file","image"]
@@ -199,41 +216,37 @@ Because sending and storing files as their base64 hash is ineffective, files hav
     }
     ```
 
-### Content Type Definition parameters
 
-| Parameter  | Description |
-| ---------- | ----------- |
-| id         | The id is given by the backend by which the file on the disk is named. The `id` property is unique, final and immutable and is used to create the URI of the uploaded object. |
-| extension  | File extension without dot |
-| fileName   | Full name of uploaded file |
-| mimeType   | Mime type of uploaded file |
-| size       | Size of file in bytes |
-| type       | Type of the file, it can be 'image' or 'file' |
-| source     | Source of the file, it can be 'disk' or 'unsplash' |
-| externalId | Id of the photo on unsplash if it was downloaded from there
-| url        | Url to original image without API host (e.g. /image/0x0/_media-456456.jpg) |
-| height     | Height, or 0 for 'file' type |
-| width      | Width, or 0 for 'file' type |
 
 ##Content Object
 
 Media upload endpoint creates Content Object automatically when you use `save = 1` parameter. It would be best if you only used `getMedia` and `listMedia` endpoints, as changing the `_media` objects can lead to unexpected behaviour.
 
-??? "Deprecated, old, two steps way"
 
-    Saving the `_media` type object can only take place after the file has been saved on the server. At that point, the object identifier is assigned. The `id` property is unique, final and immutable and is used to create the URI of the uploaded object. 
+##Viewing and resizing photos, returning files
 
-
-##Images resizing
-
-Flotiq automatically scale images and save them for future, faster use, if the size requested by the user or generator does not yet exist.
-
-##Viewing photos, returning files
-
-Resized images are returned by endpoint `/image/{width}x{height}/{key}` where 
+To fetch resized image use the `/image/{width}x{height}/{key}` endpoint where 
 `width` and `height` are the dimensions of the scaled photo and key is its `id` and `extension`. 
+
 To download the original photo, or download a non-photo file as width and height, 
 enter `0`, e.g. `/image/0x0/_media-54723892824.doc`.
 
 !!! example 
     `image/1920x0/_media-5472384.jpg` will choose a photo with a width of 1920px and a proportional height of id `_media-5472384`, the file will be JPG. The extension must match the original extension of the uploaded file.
+    
+Flotiq automatically scale images and save them for future, faster use, if the size requested by the user does not yet exist.  
+    
+## Additional notes
+
+We've changed the upload process during Flotiq evolution. Below you can see docs about old, deprecated upload process:
+
+??? "Deprecated, old, "two steps" way"
+
+    The process of uploading files to the media library consists of two steps:
+    
+    1. Upload the file to `/api/media` endpoint (via a `POST` request). The response
+       will be a JSON payload with information about the created entity.
+        
+    2. Next step is to create Content Object passing data from step 1. (id, size, type, etc.) with Content Type Definition of `_media` type to the `/api/v1/content/_media`  endpoint.
+    
+    Saving the `_media` type object can only take place after the file has been saved on the server. At that point, the object identifier is assigned. The `id` property is unique, final and immutable and is used to create the URI of the uploaded object. 


### PR DESCRIPTION
- moved deprecated infos to the last section
- added intro text
- changed section order (e.g. schema defnition can be lower then response attributes list)
- removed unsplash info (current description was unclear)