### PR TITLE
resolves #55; removed `zapier integration` from a navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,6 @@ nav:
     - 'Full-text search': API/search.md
     - 'Working with media': API/media-library.md
     - 'Workflows': 'API/workflow/content-publishing-workflow.md'
-    - 'Zapier & integrations': API/zapier.md
   - Dashboard:
     - 'Overview': panel/index.md
     - 'Content types': panel/content-types.md


### PR DESCRIPTION
`Zapier integration` was moved to `Flotiq Universe` section.