### PR TITLE
pin to mkdocs-material 8.5.11 - fix search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs
-mkdocs-material >= 7.3
+mkdocs-material==8.5.11
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
After recent deployment flotiq.com/docs lost search functionality:
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/3079734/212381245-6fbb49bd-a3b1-474c-a452-c86b2b75079b.png">

There seems to be an issue with mkdocs-material - https://github.com/squidfunk/mkdocs-material/issues/4851 and because of that let's dowgrade to latest from 8.x line to bring back the search:
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/3079734/212381474-49efb300-a1d2-465b-9484-418c673e9076.png">
