### PR TITLE
#21900 notEquals typo

### DIFF
--- a/docs/API/content-type/listing-co.md
+++ b/docs/API/content-type/listing-co.md
@@ -166,7 +166,7 @@ Filter types
 | Type               | Description                                                                                                                                                   |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | equals             | Object parameter must be equal to `filter`, can be used with string type parameters                                                                           |
-| notEquals          | Object parameter must not be equal to `filter`, can be used with string type parameters                                                                       |
+| notEqual          | Object parameter must not be equal to `filter`, can be used with string type parameters                                                                       |
 | contains           | Object parameter must contain `filter`, can be used with every type parameters                                                                                |
 | notContains        | Object parameter must not contain `filter`, can be used with every type parameters                                                                            |
 | startsWith         | Object parameter must start with `filter`, can be used with string type parameters                                                                            |


### PR DESCRIPTION
fix typo on name of the "notEqual" filter in `listing content objects` section