### PR TITLE
Add info to deprecated dives

### DIFF
--- a/docs/Deep-Dives/Building-a-blog-in-3-minutes.md
+++ b/docs/Deep-Dives/Building-a-blog-in-3-minutes.md
@@ -1,6 +1,13 @@
 title: Building a blog in 3 minutes with Flotiq, Gatsby and Heroku | Flotiq docs
 description: A deep dive tutorial on how to build your first blog using a headless CMS system like Flotiq, GatsbyJS and Heroku.
 
+!!! caution
+    This tutorial is based on a deprecated starter. We strongly advise you to look at our new blog starters - 
+    [Gatsby Blog 1 – Gradient](https://flotiq.com/starters/gatsby-blog-1-gradient) and 
+    [Gatsby Blog 2 – Modern](https://flotiq.com/starters/gatsby-blog-2-modern) - described in 
+    [our blog post](https://flotiq.com/blog/flotiq-starter-gatsby-blog). Look at our other 
+    [starters](https://flotiq.com/starters/) if Gatsby blogs don't match your need.
+
 # Building a blog in 3 minutes with Flotiq, Gatsby and Heroku
 
 In this deep dive you will learn how easy it is to build and deploy a blog with Flotiq, Gatsby and Heroku. Follow along and you should end up with a working blog page in no more than 3 minutes!

--- a/docs/Deep-Dives/index.md
+++ b/docs/Deep-Dives/index.md
@@ -5,7 +5,7 @@ description: Browse through the deep dives and learn how to integrate Flotiq in 
 
 This section contains several walk-throughs that will help you get familiar with Flotiq with a specific use case.
 
-1. Start with the [Building a blog in 3 minutes](Building-a-blog-in-3-minutes.md) deep dive. You will get a good introduction to the most important parts of the system, yet the tutorial is very simple and you'll quickly end up with a live site, without writing a line of code.
+1. Start with the [Flotiq Starter - Gatsby Blog](https://flotiq.com/blog/flotiq-starter-gatsby-blog) article. You will get a good introduction to the most important parts of the system, yet the tutorial is very simple and you'll quickly end up with a live site, without writing a line of code.
 2. Once you're comfortable with Flotiq - go through the [Importing posts from Wordpress](wordpress-import.md) tutorial. This will get you familiar with your own Flotiq SDKs and will show you how to quickly migrate content from Wordpress to Flotiq.
 
 We can't wait to see what you'll build!

--- a/docs/Deep-Dives/jamstack-recipes-website-complex-data-structures.md
+++ b/docs/Deep-Dives/jamstack-recipes-website-complex-data-structures.md
@@ -1,6 +1,13 @@
 title: Building a stunning recipe website with Flotiq and Gatsby | Flotiq docs
 description: A deep dive tutorial on Flotiq's complex data structures and accidentally building a stunning recipes website with Gatsby.
 
+!!! caution
+    This tutorial is based on a deprecated starter. We strongly advise you to look at our new blog starters - 
+    [Gatsby Recipe 1 – Black and White Classic](https://flotiq.com/starters/gatsby-recipe-1-black-and-white-classic) and 
+    [Gatsby Recipe 2 – All you can eat](https://flotiq.com/starters/gatsby-recipe-2-all-you-can-eat) - described in 
+    [our blog post](https://flotiq.com/blog/recipe-website-using-complex-data-structure-and-gatsby-starter). Look at our other 
+    [starters](https://flotiq.com/starters/) if Gatsby recipe website don't match your need.
+
 # Building a recipes website using complex data structures
 
 ## Introduction

--- a/docs/Deep-Dives/node-js-ecommerce-snipcart-gatsby-demo.md
+++ b/docs/Deep-Dives/node-js-ecommerce-snipcart-gatsby-demo.md
@@ -1,6 +1,12 @@
 title: Start selling online - Node.js e-commerce tutorial using Snipcart, Flotiq and Gatsby | Flotiq deep dives
 description: Start selling products online instantly. Use our step-by-step tutorial on Snipcart, Gatsby and Flotiq and put your e-commerce live in 5 minutes.
 
+!!! caution
+    This tutorial is based on a deprecated starter. We strongly advise you to look at our new blog starters - 
+    [Gatsby eCommerce 1 – Green Shop](https://flotiq.com/starters/gatsby-ecommerce-1-green-shop) and 
+    [Gatsby eCommerce 2 – Merch Store](https://flotiq.com/starters/gatsby-ecommerce-2-merch-store). Look at our other 
+    [starters](https://flotiq.com/starters/) if Gatsby recipe website don't match your need.
+
 # Start selling online with Snipcart, Flotiq, Gatsby and Heroku
 
 This time, we'll dive deep into building e-commerce with Snipcart, Flotiq and Gatsby. We'll start with a fresh Flotiq account, build a Content Type Definition, hook it up with a Gatsby starter and finally - deploy it live using Heroku.


### PR DESCRIPTION
Since some of the repos are archived and replaced with new starters, we are starting a process of updating the docs content from clear deprecation info in those deep dives, that are based on the deprecated examples.

![image](https://user-images.githubusercontent.com/2618837/233662802-22765fa5-42d8-48b7-ac91-df1f935812aa.png)
