### PR TITLE
upgrade mkdocs-material to 9.x

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,9 +12,6 @@ theme:
      language: en
      palette:
          primary: '#0083FC'
-#     icon:
-#       edit: material/pencil 
-#       view: material/eye
      features:
        - navigation.instant
        - navigation.top

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Flotiq Developer Documentation
 site_url: https://flotiq.com/docs/
+repo_url: https://github.com/flotiq/flotiq-docs/
+edit_uri: edit/master/docs/
 copyright: Copyright &copy; 2019 onwards <a target="_blank" href="https://www.flotiq.com/">Flotiq<a>
 dev_addr: 0.0.0.0:4000
 theme:
@@ -10,9 +12,17 @@ theme:
      language: en
      palette:
          primary: '#0083FC'
+#     icon:
+#       edit: material/pencil 
+#       view: material/eye
      features:
        - navigation.instant
        - navigation.top
+       - content.action.edit
+       - content.action.view
+       - search.suggest
+       - search.highlight
+
 plugins:
   - search
   - awesome-pages
@@ -36,6 +46,7 @@ markdown_extensions:
   - meta
   - toc:
       permalink: true
+      title: On this page
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.details

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs
-mkdocs-material==8.5.11
+mkdocs-material==9.1.*
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin

--- a/theme/partials/content.html
+++ b/theme/partials/content.html
@@ -15,6 +15,14 @@
     {% endif %}
 </div>
 
+<!-- Tags -->
+{% if "material/tags" in config.plugins %}
+  {% include "partials/tags.html" %}
+{% endif %}
+
+<!-- Actions -->
+{% include "partials/actions.html" %}
+
 {% if not "\x3ch1" in page.content %}
 <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -118,13 +118,11 @@
         </div>
         <div class="md-header__inner">
             <!-- Button to open search modal -->
-            {% if "search" in config["plugins"] %}
-            <label class="md-header__button md-icon" for="__search">
+            {% if "material/search" in config.plugins %}
+              <label class="md-header__button md-icon" for="__search">
                 {% include ".icons/material/magnify.svg" %}
-            </label>
-
-            <!-- Search interface -->
-            {% include "partials/search.html" %}
+              </label>
+              {% include "partials/search.html" %}
             {% endif %}
 
             <!-- Repository information -->


### PR DESCRIPTION
This PR is introducing minimal changes to the code, required to upgrade mkdocs-material to 9.x.
I'm also adding the `repo_url` and `edit_uri` mkdocs settings in order to link to github repo from each docs page and allow easy editing.

Before:
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/3079734/235250896-f06da8bf-d931-45c0-b65b-a5bf93f84de6.png">

after:
<img width="1540" alt="image" src="https://user-images.githubusercontent.com/3079734/235250934-229363c9-776e-4d25-83c8-a953b7413b04.png">
