### PR TITLE
#23578 add copy code button

### DIFF
--- a/docs/css/flotiq.css
+++ b/docs/css/flotiq.css
@@ -147,6 +147,13 @@ pre::before {
     background-color: #313131 !important;
   }
 
+  .md-clipboard:after {
+    color: #c2c2c2;
+  }
+
+  .md-dialog__inner.md-typeset {
+    color:white;
+  }
 
   /*
   scroll bar size

--- a/docs/css/flotiq.css
+++ b/docs/css/flotiq.css
@@ -152,7 +152,7 @@ pre::before {
   }
 
   .md-dialog__inner.md-typeset {
-    color:white;
+    color:#c2c2c2;
   }
 
   /*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
        - content.action.view
        - search.suggest
        - search.highlight
+       - content.code.copy
 
 plugins:
   - search


### PR DESCRIPTION
added copy code button for code snippets

color of the button is #c2c2c2 to better match dark code block background

![image](https://github.com/flotiq/flotiq-docs/assets/109143307/1e36d293-aa6f-49cd-ab28-30441a3967bc)

![image](https://github.com/flotiq/flotiq-docs/assets/109143307/7c8a52c9-9fb7-46c4-93bf-eb383cf9ec02)
