### PR TITLE
contentTypeName in sync webhook

### DIFF
--- a/docs/panel/webhooks/sync.md
+++ b/docs/panel/webhooks/sync.md
@@ -35,7 +35,7 @@ All sync webhooks generate a payload according to the following schema:
     "subject":"content-object",
     "event": "pre-create",
     "sequenceNumber": 0,
-    "contentTypeName" : "ContetnTypeName"
+    "contentTypeName" : "ContentTypeName",
     "payload": {
         ... <-- this is the object that was originally sent to Flotiq
     }

--- a/docs/panel/webhooks/sync.md
+++ b/docs/panel/webhooks/sync.md
@@ -35,6 +35,7 @@ All sync webhooks generate a payload according to the following schema:
     "subject":"content-object",
     "event": "pre-create",
     "sequenceNumber": 0,
+    "contentTypeName" : "ContetnTypeName"
     "payload": {
         ... <-- this is the object that was originally sent to Flotiq
     }


### PR DESCRIPTION
This MR is adding an additional `contentTypeName` field to sync webhooks documentation.