### PR TITLE
Disqus in dark mode - paddings

### DIFF
--- a/docs/css/flotiq.css
+++ b/docs/css/flotiq.css
@@ -145,8 +145,10 @@ pre::before {
   }
 
   #disqus_thread {
-    background-color: black;
     color: #e9ebfc;
+    padding: 20px;
+    background: white;
+    border-radius: 15px;
   }
 }
   /*


### PR DESCRIPTION
Before:

![image](https://github.com/flotiq/flotiq-docs/assets/645716/0f15d137-62f7-4fe6-b448-55a698b2f0a9)

After:

![image](https://github.com/flotiq/flotiq-docs/assets/645716/356b0adb-414d-4ef8-a960-bd67112b6e04)

Toggle light/dark

[Get-Started-with-Flotiq-API-Integration---Flotiq-Developer-Documentation (1).webm](https://github.com/flotiq/flotiq-docs/assets/645716/543b969b-c80f-4c11-9c05-39456c975f2e)

