### PR TITLE
Dark-mode-hotfix

### DIFF
--- a/docs/css/flotiq.css
+++ b/docs/css/flotiq.css
@@ -130,7 +130,21 @@ pre::before {
     background: white;
     border-radius: 15px;
   }
+
+  .md-search-result__link:focus,
+  .md-search-result__link:hover,
+  .md-search-result__more summary:focus,
+  .md-search-result__more summary:hover,
+  .md-search-result__meta {
+    background-color: hsl(232, 15%, 26%);
+  }
+
+  .md-search__input {
+    background-color: hsl(232, 15%, 36%);
+    color: #e9ebfc;
+  }
 }
+
   /*
   /////////////////
   // Code Blocks //


### PR DESCRIPTION
Corrected search result colors, cleaned up comments after previous dark mode pr.

![image](https://github.com/flotiq/flotiq-docs/assets/109143307/5dbe6835-9e7f-4c87-b63f-249fddb82eba)

Colors used DO NOT come from Flotiq color palette, but rather from mkdocs default slate palette, sometimes in different shades