### PR TITLE
add script for scrolling window up after loading new page #23592

### DIFF
--- a/docs/js/flotiq.js
+++ b/docs/js/flotiq.js
@@ -1,4 +1,12 @@
 document.addEventListener("DOMContentLoaded", function () {
+    // scroll the window to the top of the page after switching documents
+    var currentHash = window.location.hash;
+    window.scrollTo(0, 0);
+
+    if (currentHash) {
+        window.location.hash = currentHash;
+    }
+
     load_navpane();
 });
 


### PR DESCRIPTION
Added script that scrolls the page up to top when switching pages (viewing page via url with hash is unaffected)
![docsscroll](https://github.com/flotiq/flotiq-docs/assets/109143307/ca7f60cd-cc2d-4f2b-be29-d416355e388f)
