### PR TITLE
ref #22922 - add correct link to asynchronous webhhook from overview page

### DIFF
--- a/docs/panel/webhooks/index.md
+++ b/docs/panel/webhooks/index.md
@@ -9,7 +9,7 @@ Webhooks are a form of contacint external systems when an event occurs in Flotiq
 
 We support 2 types of webhooks:
 
-- [asynchronous](async) - this is the type you are probably most familiar with, you can think of those as notifications sent to external systems *after* an event happens in Flotiq, without altering the processing flow on Flotiq side,
+- [asynchronous](async-co-webhook) - this is the type you are probably most familiar with, you can think of those as notifications sent to external systems *after* an event happens in Flotiq, without altering the processing flow on Flotiq side,
 - [synchronous](sync) - these webhooks are synchronous calls that are made to an external system *during* the processing of data in Flotiq, for example to perform data validation.
 
 Follow the links above to read more about each type of webhooks and example use cases.


### PR DESCRIPTION
Add correct redirect link for webhook async after last update.

![image](https://github.com/flotiq/flotiq-docs/assets/110835434/8c7de226-616a-4355-9519-8a646acd2f0a)
