### PR TITLE
fix double custom links page in navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,7 +147,6 @@ nav:
       - 'Sync webhooks':  panel/webhooks/sync.md
       - 'Sync examples': panel/webhooks/sync-examples.md
     - Plugins:
-      - 'Custom Links': panel/Plugins/Custom-links.md
       - 'Gatsby Cloud': panel/Plugins/Gatsby-cloud-integration.md
       - 'Netlify': panel/Plugins/Netlify-integration.md
       - 'Custom Links': panel/Plugins/Custom-links.md


### PR DESCRIPTION
fixed double `custom link` page links on left navbar

![image](https://github.com/flotiq/flotiq-docs/assets/109143307/d421751c-79ab-481a-9f78-6128b732e0a8)
