### PR TITLE
#24688 Fix links to dynamic pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ pip install -r requirements.txt
 To start server use:
 
 ```bash
-bash .github/scripts/get-plugins-docs.sh # Pull dynamically generated plugin docs
+# Use SOURCE_EDITOR_URL variable to point to speciffic dashboard url. By default, SOURCE_EDITOR_URL=https://editor.flotiq.com is used.
+bash .github/scripts/get-plugins-docs.sh # Pull dynamically generated plugin docs. 
 mkdocs serve # Start devlopment server
 ```
 
@@ -53,3 +54,27 @@ If you wish to talk with us about this project, feel free to hop on [![Discord C
 If you found a bug, please report it in [issues](https://github.com/flotiq/flotiq-docs/issues).
 
 We also welcome any PR with documentation improvements (or typo fixes ;) ).
+
+## Aliasing
+Some files are dynamically generated (e.g. all pages describing events and classes for plugin API). Those pages can be referred with an alias:
+
+```md
+<!-- Refer to PluginInfo page -->
+[[PluginInfo.md]] 
+
+<!-- Refer to PluginInfo page with an alternative name -->
+[[PluginInfo.md|Page about PluginInfo class]] 
+
+<!-- Refer to header on PluginInfo page with an alternative name -->
+[[PluginInfo.md#example-header|Example section on the page]]
+```
+
+You can also add an alias to any existing page by dyfining it in the meta section of the markdown file:
+
+```md
+<!-- Start of the markdown file -->
+alias: some-example-alias
+
+# Example page
+...
+```

--- a/docs/panel/PluginsDevelopment/plugins.md
+++ b/docs/panel/PluginsDevelopment/plugins.md
@@ -58,7 +58,7 @@ What happens here?
   
     This is the best place to perform initialization work. E.g. inject `<style>` elements with your CSS classes.
 
-3. **Event handling** - After all initialization code is executed, your plugin will wait for events from Flotiq UI. Each time the event occurs in Flotiq, your event callback will be executed. Each event has a different set of parameters and expects different results. For example `::render` events will expect HTML content as a result, while `::config` events will not take any result and expect you to modify existing config. For details, please refer to [Flotiq Event Types](PluginDocs/Events.md).
+3. **Event handling** - After all initialization code is executed, your plugin will wait for events from Flotiq UI. Each time the event occurs in Flotiq, your event callback will be executed. Each event has a different set of parameters and expects different results. For example `::render` events will expect HTML content as a result, while `::config` events will not take any result and expect you to modify existing config. For details, please refer to [[Events.md|Flotiq Event Types]].
 
 ### API permissions
 
@@ -68,7 +68,7 @@ Flotiq UI plugins are allowed to access API only with pre-prepared API client, a
 
 **Important**: plugins are not using own API Keys, nor there are direct `fetch` calls from plugin code to API. Instead, plugins **must** use the provided API client. All of the write actions will be registered as if a user made the change.
 
-To be able to do it, a plugin needs to request API access with [`permissions`](PluginDocs/PluginInfo.md#class-pluginpermission) field during registration:
+To be able to do it, a plugin needs to request API access with [[PluginInfo.md#class-pluginpermission|`permissions`]] field during registration:
 
 ```javascript
 FlotiqPlugins.add({
@@ -359,7 +359,7 @@ Your plugin also must contain all required information in the `plugin-manifest.j
 
 </details>
 
-For more details on the required fields, see [PluginInfo](PluginDocs/PluginInfo.md).
+For more details on the required fields, see [[PluginInfo.md]].
 
 If your plugin is ready for wider use within your organization:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ theme:
        - content.code.copy
 
 plugins:
+  - alias:
+      verbose: true
+      use_anchor_titles: true
   - search
   - awesome-pages
   - glightbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-include-dir-to-nav
 mkdocs-glightbox
+mkdocs-alias-plugin


### PR DESCRIPTION
A couple of places in plugin documentation refer to pages dynamically pulled from the editor. To Avoid future problems, I replaced them with aliases, which are dynamically added to each of those pages.