### PR TITLE
mark the example query regarding using API keys as part of the request URL as code

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -53,7 +53,11 @@ You can authenticate your requests by `X-AUTH-TOKEN` header, or by the query par
 
 An example query request with endpoint:
 
-`https://api.flotiq.com/api/v1/content/your_content_name?auth_token=YOUR_AUTH_TOKEN`:
+!!! Example
+    <pre class="h-3em">
+    <code class="hljs plaintext">https://api.flotiq.com/api/v1/content/your_content_name?auth_token=YOUR_AUTH_TOKEN
+    </code>
+    </pre>
 
 Or an example queries with `X-AUTH-TOKEN` header:
 

--- a/docs/css/flotiq.css
+++ b/docs/css/flotiq.css
@@ -256,6 +256,10 @@ pre::before {
   border: 0;
 }
 
+.h-3em {
+  height: 3em;
+}
+
 .flotiq-form .mat-fab.mat-primary, .flotiq-form .mat-flat-button.mat-primary, .flotiq-form .mat-mini-fab.mat-primary, .flotiq-form .mat-raised-button.mat-primary[type="submit"] {
   background-color: #0083FC;
 }


### PR DESCRIPTION
Added: 
- a code block in the example query regarding using API keys as part of the request URL (https://flotiq.com/docs/API/#usage)

<img width="939" alt="api-keys-code" src="https://github.com/user-attachments/assets/9e5907fb-f2e0-48e2-b5dd-491ee80e6acd">
