### PR TITLE
Overview routing update for Content Objects

### DIFF
--- a/docs/panel/ContentObjects/index.md
+++ b/docs/panel/ContentObjects/index.md
@@ -3,7 +3,7 @@ tags:
   - Content Creator
 ---
 
-# Overview
+# Content objects
 
 Once a Content Type has been defined in the system - the user can create Content Objects of that Content Type.
 This is done either directly through the API or via the convenient Content Entry tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,7 +156,7 @@ nav:
     - 'Flotiq Forms': panel/flotiq-forms-add-forms-to-websites.md
     - 'Predefined Content Types': panel/predefined-content-types.md
     - 'Content objects':
-      - 'Overview': panel/ContentObjects/overview.md
+      - 'Overview': panel/ContentObjects/index.md
       - 'Field types': panel/ContentObjects/field-types.md
       - 'Draft & Public': panel/ContentObjects/draft-public.md
     - 'Media library': panel/media-library.md


### PR DESCRIPTION
Fix routing to be backward-compatible and unified with other "overview" pages (without "overview" in the URL).

Before
![image](https://github.com/user-attachments/assets/0d60751e-5eb9-449d-8ee2-0dee551faf71)

After
![image](https://github.com/user-attachments/assets/f2716db3-f9d3-48e2-a5ca-7b16cb4fac67)
