### PR TITLE
Fix redirect loop that happens if url has query params

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -37,7 +37,8 @@ async function handleEvent(event) {
   const has_assets_or_images_in_the_link = /\/(assets|images)\//.test(url.pathname);
   const has_file_extension = /[^\/]+\.[^\/]+$/.test(url.pathname);
   if(!has_slash_at_the_end && !has_assets_or_images_in_the_link && !has_file_extension) {
-    return Response.redirect(`${event.request.url}/`, 301);
+    url.pathname += '/';
+    return Response.redirect(url.toString(), 301);
   }
 
   try {


### PR DESCRIPTION
Currently, adding slash to the url causes redirect loop if the url contains query params.

![image](https://github.com/user-attachments/assets/d8d44110-c282-49a0-a60e-3b57f364c55c)
