### PR TITLE
Fix command name for execel-export in CLI example

### DIFF
--- a/docs/CLI/excel-data-migration.md
+++ b/docs/CLI/excel-data-migration.md
@@ -19,7 +19,7 @@ If you wish to use our Flotiq - Excel migrator directly, you can use our [flotiq
 The command looks like this:
 
 ```bash
-flotiq excel-import [ctdName] [filePath] [flotiqApiKey]
+flotiq excel-export [ctdName] [filePath] [flotiqApiKey]
 ```
 { data-search-exclude }
 


### PR DESCRIPTION
This PR fixes the name of the command in the CLI Excel export description example